### PR TITLE
Fixing build error when bumping up the poky version to rocko

### DIFF
--- a/daemons/gptp/linux/src/linux_hal_generic_adj.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic_adj.cpp
@@ -31,7 +31,7 @@
 
 ******************************************************************************/
 
-#include <linux/timex.h>
+#include <sys/timex.h>
  // avoid indirect inclusion of time.h since this will clash with linux/timex.h
 #define _TIME_H  1
 #define _STRUCT_TIMEVAL 1


### PR DESCRIPTION
We shouldn't include the linux/timex.h since that will cause
redefentions of structs. Instead we should use sys/timex.h.